### PR TITLE
fix the "package" makefile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ For best practices / contributing rules see [CONTRIBUTING.md](.github/CONTRIBUTI
 
 ## Requirements
 
-- Helm
-- [Helm push plugin](https://github.com/chartmuseum/helm-push)
-- Access to repository and Token
+- [helm cli >=3.8](https://github.com/helm/helm/releases)
+- [git cli](https://git-scm.com)
+- [yq v4 (mikefarah) ](https://github.com/mikefarah/yq/releases)
+- Optional: Write access to registry (`write:packages` in case of ghcr.io)
 
 ### List of helm chart packages provided
 
@@ -34,14 +35,22 @@ Run:
 make -C scripts/ build
 ```
 
-### Cleanup of old packaged charts
+### Cleanup of decommission charts
 
 During the build process, previously packaged Helm charts are retained in the [packaged-charts](./packaged_charts/) folder and remain referenced in the [index](index.yaml) file. This behavior is intentional, as it ensures that older chart versions remain accessible for compatibility and historical purposes.
 
-To remove specific older chart versions or decommission charts entirely, delete the necessary files in [packaged-charts](./packaged_charts/) and [charts](./charts/) folders respectively and rebuild the index.
+To remove specific older chart versions or decommission charts entirely, delete the necessary files in [packaged-charts](./packaged_charts/) and/or [charts](./charts/) folders respectively and run the `clean` target.
+
+```bash
+make -C scripts/ clean
+```
+
+### Regenerate Index
+
+If there's any problem with the index file, it is possible to regenerate it from scratch.
 
 > [!IMPORTANT]  
-> This will rebuild the complete helm repository index removing any unlinked references and fixing any potential issues with the file. This also has an unintended consequence of updating the `created` timestamp of all the remaining charts in the repository.
+> This will rebuild the helm repository index removing any unlinked references and fixing any potential issues with the file. This also has an unintended consequence of updating the `created` timestamp of all the remaining charts in the repository.
 
 ```bash
 make -C scripts/ reindex
@@ -51,17 +60,18 @@ make -C scripts/ reindex
 
 Everything required has been created on filesystem (index.yaml + packaged_charts/*.tgz), just push your changes to the main branch (via pull request)
 
-### Publish to a helm repository (Gitlab, Harbor, Artifactory)
+### Publish to oci registry
 
-To publish the all (local) charts to a remote helm repository such as Gitlab, Harbor, Artifactory, .. be sure to export environment variables for repo URL, user and password:
+To publish all local charts to a remote oci registry (such as ghcr, quay, ..), be sure to export environment variables for registry user and password.
+The variable for registry url is optional and defaults to `ghcr.io/<git-remote-repo>`  (git-remote-repo is derived from the output of `git config --get remote.origin.url`)
 
 ```bash
-export REPO_URL="https://github.com/gr8it/charts-openshift/"
-export REPO_USERNAME="chartpusher"
-export REPO_TOKEN="asd1e41123h12ey8haodasd"
+export REGISTRY_USER="registry-user"
+export REGISTRY_TOKEN="ghp_E6pjd ..... jweUO71"
+export REGISTRY_URL="my-custom-registry.io:5000/helm-charts"
 ```
 
-and run:
+To push packaged charts as oci images to a registry, run:
 
 ```bash
 make -C scripts/ publish
@@ -98,4 +108,4 @@ or replace main branch, with feature branch of your choice
 
 ## TODO
 
-- publish charts to OCI repo (ghcr.io)
+- figure out a publishing process for the oci registry

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -17,10 +17,15 @@ OUTPUT_DIR := $(shell realpath $(ROOT_DIR)/packaged_charts)
 INDEX_FILE := $(shell realpath $(ROOT_DIR)/index.yaml)
 INDEX_ROOT := $(shell dirname $(INDEX_FILE))
 
+# oci registry variables
+REGISTRY_USER  := $(shell echo $${REGISTRY_USER:-})
+REGISTRY_TOKEN := $(shell echo $${REGISTRY_TOKEN:-})
+REGISTRY_URL   := $(shell echo $${REGISTRY_URL:-ghcr.io/$$(git config --get remote.origin.url | sed -E 's#(git@github.com:|https://github.com/)##;s#.git##')})
+
 debug:
-	@echo "$${REPO_USERNAME}"
-	@echo "$${REPO_TOKEN}"
-	@echo ${REPO_URL}
+	@echo "$(REGISTRY_USER)"
+	@echo "$(REGISTRY_TOKEN)"
+	@echo "$(REGISTRY_URL)"
 	@echo "$(YQ)"
 
 lint:
@@ -89,16 +94,41 @@ check-yq:
 		exit 1; \
 	fi
 
+check-helm:
+	@if (command -v helm >/dev/null 2>&1); then \
+		version=$$(helm version --short 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' || echo "0" ); \
+		required_major=3; \
+		required_minor=8; \
+		found_major=$${version%%.*}; \
+		found_minor=$${version##*.}; \
+	else \
+		echo -e "\033[0;31mhelm cli not found; please install it.\033[0m"; \
+		exit 1; \
+	fi; \
+	if test "$$found_major" -lt "$$required_major"; then \
+		echo -e "\033[0;31mhelm version >=3.8 is required; found version $${version}.\033[0m"; \
+		exit 1; \
+	elif test "$$found_major" -eq "$$required_major" -a "$$found_minor" -lt "$$required_minor"; then \
+		echo -e "\033[0;31mhelm version >=3.8 is required; found version $${version}.\033[0m"; \
+		exit 1; \
+	fi
+
 reset-index:
-	@echo "Regenerating charts index file ... "
+	@echo -e "\033[0;36m~> Regenerating charts index file ...\033[0m"
 	@helm repo index $(CURDIR)/..
 
-publish:
-	@echo "Charts publish ... "
-	@helm repo add --force-update --username $${REPO_USERNAME} --password $${REPO_TOKEN} helm_charts_repo ${REPO_URL}
-	@for name in $(CURDIR)/../*.tgz; do\
-		echo $${name}; \
-		helm cm-push $${name} helm_charts_repo; \
+publish: check-helm
+	@echo -e "\033[0;36m~> Pushing charts to oci://$(REGISTRY_URL) ...\033[0m"
+  # check env variables
+	@if test -z "$(REGISTRY_USER)" -o -z "$(REGISTRY_TOKEN)"; then \
+		echo -e "\033[0;31mError: REGISTRY_USER and/or REGISTRY_TOKEN environment variables not set.\033[0m"; \
+		exit 1; \
+	fi
+  # login to registry
+	@echo "$(REGISTRY_TOKEN)" | helm registry login "$(REGISTRY_URL)" -u "$(REGISTRY_USER)" --password-stdin
+  # push packaged charts
+	@for pkg_file in "$(OUTPUT_DIR)"/*.tgz; do \
+		helm push "$$pkg_file" oci://$(REGISTRY_URL); \
 	done
 
 clean: check-yq


### PR DESCRIPTION
- updated the "package" target
  - `helm package` now stores files in a temp folder
  - indexing will run against packages in temp folder and then merged back to main index
  - new packages are moved from temp folder to main (`packaged_charts`) folder once indexed
- updated the "lint" target
  - adjusted the info text that is printed durning linting
- added some colors and adjusted some output text of the build process
