### PR TITLE
SPEXAPC-17809 updating claude instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(make publish*)",
+      "Bash(*make publish*)",
+      "Bash(*CHARTFOLDER=* make publish*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git push* --force*)",
+      "Bash(git push* -f*)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin master)",
+      "Bash(git push origin master:*)",
+      "Bash(git push upstream main)",
+      "Bash(git push upstream master)",
+      "Bash(helm install*)",
+      "Bash(helm upgrade*)",
+      "Bash(kubectl apply*)",
+      "Bash(oc apply*)",
+      "Bash(helmfile apply*)",
+      "Bash(helmfile sync*)",
+      "Edit(../conf-*/**)",
+      "Write(../conf-*/**)",
+      "Edit(../conf-*)",
+      "Write(../conf-*)"
+    ]
+  }
+}

--- a/.claude/skills/migrate-chart/SKILL.md
+++ b/.claude/skills/migrate-chart/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: migrate-chart
+description: Convert an existing static OpenShift manifest set (deployed outside GitOps, living in the conf repo's ocp-<environment>/<component>/ folders) into a Helm chart in charts-openshift, so it can be adopted into ArgoCD GitOps. Use when asked to "migrate X to a chart", "gitops-ify X", "bring X under helm", or similar — not for a brand-new use case (use new-chart for that).
+---
+
+# Migrate chart
+
+Turn a pre-existing, manually-applied set of manifests into a chart that renders to the **same objects**, parametrized only where genuinely necessary. The goal is a chart ArgoCD can adopt without an unexpected diff on first sync — not a redesign of the component.
+
+## 1. Locate the source manifests
+
+The conf repo is a separate git repository, usually checked out as a sibling directory (e.g. `conf-<customer>`). If you don't already have its path from context, ask rather than guessing.
+
+Static, pre-GitOps manifests for a component live at:
+
+```
+<conf-repo>/ocp-<environment>/<component>/*.yaml
+```
+
+for each of `dev01`, `test01`, `prod01` (and sometimes `hub01`, if the component has hub-cluster objects — see the watch-out below). Read all environment copies before writing anything.
+
+Ignore/flag non-manifest files in that folder (`.sh` scripts, `.ini` config, README) — these aren't candidates for templating and need a human decision on how to handle them; don't try to force them into the chart.
+
+**Watch out:** filenames are sometimes prefixed with a cluster name (e.g. `03-hub01-hostedcluster-idp.yaml`, `04-dev01-secret-ad-bind.yaml`) inside a single environment's folder. This means some objects belong to the **hub cluster** (installed once, not per-workload-environment) while others repeat per DEV01/TEST01/PROD01. Don't assume every file in `ocp-dev01/<component>/` is a DEV01-cluster object — check the target cluster per file before deciding what's "per-environment".
+
+## 2. Diff across environments, classify every difference
+
+For each field that differs between the DEV01/TEST01/PROD01 (and hub01, if applicable) copies of a manifest:
+
+1. **Check if `apc-global-overrides` already covers it** (cluster name, environment short name, apps domain, shared stores, etc. — see the helper list in `charts/apc-global-overrides/README.md`). If yes, use the helper — do not turn it into a chart value.
+2. **If it's a genuine per-environment business value** (image tag, replica count, resource sizing, a feature toggle) — promote it to `values.yaml`, minimal-values style, same as new-chart.
+3. **If it's neither** — don't guess. Ask the user whether it's a real configuration need or an accident of how the static manifests were hand-written (e.g. leftover copy-paste drift).
+
+Anything that's **identical** across all environment copies should be hardcoded straight into the template — it is not a configuration point.
+
+## 3. Scaffold the chart
+
+Same structure and requirements as `new-chart` (Chart.yaml, values.yaml, values.example.yaml, values.lint.yaml if needed, values.schema.json, one resource per template file, `namespace: {{ .Release.Namespace }}` everywhere, tests/snapshot_test.yaml). Naming follows the same component-naming convention — the chart name doesn't have to match the conf-repo folder name if the naming convention implies a different suffix (e.g. it's actually a `-config` chart, not a bare component).
+
+## 4. Verify equivalence, not just "it renders"
+
+The bar for a migration is that `helm template` output matches the original static manifest for a given environment, modulo intentional, explained changes (e.g. adding `namespace: {{ .Release.Namespace }}` where it was implicit before). Concretely:
+
+```bash
+helm template <name> charts/<name> -f charts/<name>/values.example.yaml
+```
+
+Diff this against the actual static manifest for at least one environment (prefer dev01) and call out every difference to the user with a reason — don't silently accept drift, and don't silently "improve" the object (add fields, change defaults) beyond what step 2 concluded was necessary.
+
+Also run the standard gate: `CHARTFOLDER=<name> make lint` and `CHARTFOLDER=<name> make unittest` must pass.
+
+## 5. What this skill does NOT do
+
+- It never edits, commits, or pushes to the conf repo. Registering the new chart for actual GitOps deployment (adding it to `gitops/environments/<env>/versions.yaml.gotmpl` and creating `gitops/components/<component>/values.<env>.yaml.gotmpl`) happens in that repo's own session — end by listing exactly what needs to be added there, as a checklist for the user, not as an auto-applied change.
+- It never deletes or edits the original static manifests in `ocp-<environment>/<component>/`. Decommissioning those is a separate, human-led step taken only after the chart is deployed and reconciled by ArgoCD.
+- Same PR boundaries as new-chart: commit + open a PR in charts-openshift, never `make publish`, never merge, never force-push.

--- a/.claude/skills/migrate-chart/SKILL.md
+++ b/.claude/skills/migrate-chart/SKILL.md
@@ -9,7 +9,7 @@ Turn a pre-existing, manually-applied set of manifests into a chart that renders
 
 ## 1. Locate the source manifests
 
-The conf repo is a separate git repository, usually checked out as a sibling directory (e.g. `conf-<customer>`). If you don't already have its path from context, ask rather than guessing.
+The conf repo is a separate git repository, usually checked out as a sibling directory (e.g. `conf-<customer>`). There is no single conf repo — every customer has their own, and charts-openshift itself has no way to know which one applies to this task. Resolve it from what's already granted in the local session, or from the task's own context (customer/ticket); if more than one `conf-*` sibling is present and it's still not obvious which one, ask — never guess between them.
 
 Static, pre-GitOps manifests for a component live at:
 

--- a/.claude/skills/new-chart/SKILL.md
+++ b/.claude/skills/new-chart/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: new-chart
+description: Scaffold a brand-new Helm chart in charts-openshift for a new use case, following repo conventions (values files, schema, tests, naming). Use when asked to "create a new chart", "add a chart for X", "package X as a chart", or similar — not for converting an existing static manifest (use migrate-chart for that).
+---
+
+# New chart
+
+Scaffold a new chart under `charts/<name>/` that is correct on the first PR — matching every convention in `.github/copilot-instructions.md` (symlinked as `CLAUDE.md`), not just the ones visible in nearby example charts. Several existing charts in this repo predate the current conventions and are missing required files (e.g. `values.schema.json`) — don't copy that gap forward.
+
+## 1. Clarify before scaffolding
+
+Don't guess on these — ask the user if not already stated:
+
+- **Component name.** Check it against the naming convention (`<component>`, `<component>-operator`/`-helm`, `<component>-config`/`-instance`/`-policies`) — pick the suffix based on what the chart actually does, not habit.
+- **What Kubernetes/OpenShift resources it creates.** Enough to know the template list up front.
+- **What genuinely differs between DEV01/TEST01/PROD01** for this component (image tag, replica count, resource sizes, feature toggle). Everything else should come from `apc-global-overrides` or be hardcoded — see values.yaml Conventions in the root instructions. If the user asks for a config knob that isn't a real per-environment difference, push back before adding it.
+- Whether it needs to install an operator (→ ACM `operatorpolicy` pattern) vs. configure one already installed (→ `-config`/`-instance` chart depending on a CR).
+
+## 2. Scaffold
+
+```
+charts/<name>/
+  Chart.yaml
+  values.yaml
+  values.example.yaml
+  values.lint.yaml        # only if helm lint needs globals absent from values.yaml
+  values.schema.json
+  templates/
+    _helpers.tpl           # only if needed
+    <resource>.yaml         # one resource per file
+  tests/
+    snapshot_test.yaml
+```
+
+- `Chart.yaml`: `apiVersion: v2`, `type: application`, `version: 1.0.0`. Add the `apc-global-overrides` dependency if the chart uses any of its helpers — check `charts/apc-global-overrides/Chart.yaml` for the current version to pin, don't assume.
+- `values.yaml`: only the minimal per-environment values identified in step 1. Document every global value the chart relies on as a comment block (`## uses following global values => do not set here`), never set it.
+- `values.example.yaml`: realistic, non-secret values — just the overrides needed to render, plus whatever globals `values.lint.yaml`/test rendering requires.
+- `values.schema.json`: schema for everything in `values.yaml` — this is a hard requirement, not optional, even though you'll find it missing on most existing charts.
+- Every template file: `namespace: {{ .Release.Namespace }}`, flat value references (`clusterName` not `cluster.name`).
+- `tests/snapshot_test.yaml`: base snapshot against `values.example.yaml`, plus explicit cases for any conditional (feature toggle on/off, optional resource created/not created).
+- If the component involves alerting, follow PrometheusRule Conventions (severity/vendor/team labels) in the root instructions.
+
+## 3. Verify — don't declare done without this
+
+```bash
+CHARTFOLDER=<name> make lint
+CHARTFOLDER=<name> make unittest
+```
+
+Both must pass. If `make lint` fails only because of missing cluster globals, that's what `values.lint.yaml` is for — add the minimum needed, nothing more.
+
+Re-read the Definition of Done checklist in the root instructions before considering the chart finished.
+
+## 4. Handing off
+
+Per the repo's agent boundaries: you may commit to a feature branch (name includes the Jira ticket ID) and open a PR. Never run `make publish`, never merge, never force-push. Stop at "PR opened" and let a human take it from there.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,88 +2,51 @@
 
 ## Project overview
 
-The project contains **Helm charts** for deploying applications on OpenShift clusters. These charts are part of a product and are intentionally opinionated to minimize deployment complexity and favor a convention-over-configuration design paradigm. They are orchestrated from per-customer repositories (called "config repositories" or shorter "conf repos") using `helmfile` and deployed using gitops. The goal of Helmfile is to install only relevant components (charts), prepare environment values (combining global, per-environment, and per-cluster settings), and make them available to the charts in the form of global values. Charts should not access the global values directly; instead, they should use helper functions from `apc-global-overrides`, such as `{{ include "apc-global-overrides.environmentShort" . }}`, to enable override capabilities. 
+This repo (`charts-openshift`) contains **Helm charts** for deploying applications on OpenShift clusters. Charts are intentionally opinionated to minimize deployment complexity and favor convention-over-configuration.
 
-## Must follow rules
+Charts are consumed from a separate per-customer **conf repo** via `helmfile` and deployed using GitOps (ArgoCD, rendered-manifest pattern). Helmfile installs only the relevant components, prepares environment values (global + per-environment + per-cluster), and passes them to charts as global values. Charts never read those global values directly — always go through `apc-global-overrides` helpers (e.g. `{{ include "apc-global-overrides.environmentShort" . }}`), which is what makes the same chart deployable, unmodified, across DEV01 / TEST01 / PROD01.
 
-### Think Before Coding
+## Repository & agent boundaries
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+- This repo only produces charts (`charts/`, `packaged_charts/`, `index.yaml`). It has no knowledge of a specific customer or cluster — that lives entirely in the conf repo.
+- The conf repo is a **separate git repository**, typically checked out as a sibling directory. It holds two things relevant to chart work:
+  - `gitops/components/<component>/values.<common|dev01|test01|prod01>.yaml.gotmpl` — the helmfile values fed into charts already under GitOps.
+  - `ocp-<environment>/<component>/*.yaml` — static manifests for objects deployed **before** GitOps existed, not yet backed by a chart. These are the source material when migrating a component to a chart.
+- Read the conf repo for context (existing values, static manifests to migrate) but never edit, commit, or push there — changes to the conf repo happen in that repo's own session, with its own review.
+- Never run anything that touches a live cluster or acts as a deploy (`helm install`, `helm upgrade`, `kubectl apply`, `oc apply`, `helmfile apply`/`sync`). Verify work with `helm template`, `helm lint` / `make lint`, and `make unittest` only.
+- Committing to a feature branch and opening a PR is fine (branch/PR name includes the Jira ticket ID, e.g. `SPEXAPC-3288`, per [CONTRIBUTING.md](/.github/CONTRIBUTING.md)). Never run `make publish`, merge a PR, or force-push — a human always completes those steps.
 
-Before implementing:
-- State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
+## Chart authoring workflows
 
-### Simplicity First
+Two distinct workflows cover chart work, each documented under `.claude/skills/`:
 
-**Minimum code that solves the problem. Nothing speculative.**
+- **`.claude/skills/new-chart/`** — scaffold a chart from scratch for a new use case.
+- **`.claude/skills/migrate-chart/`** — convert an existing static manifest set from the conf repo (`ocp-<environment>/<component>/`) into a chart so it can be managed via GitOps.
 
-- No features beyond what was asked.
-- No abstractions for single-use code.
-- No "flexibility" or "configurability" that wasn't requested.
-- No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+For migrations: don't encode every raw diff between the DEV01/TEST01/PROD01 copies of a manifest as a values key. First check whether a difference is already covered by an `apc-global-overrides` helper (cluster domain, environment short name, etc.) — if so, use the helper, don't parametrize it. Only promote genuine per-environment business values (image tag, replica count, resource sizes, feature toggles) to `values.yaml`. If a difference doesn't clearly fall into either bucket, ask rather than guessing. See values.yaml Conventions below — the same minimal-values bar applies to migrations as to new charts.
 
-Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+## Definition of Done
 
-### Surgical Changes
+A chart change is not finished until:
 
-**Touch only what you must. Clean up only your own mess.**
+- [ ] `version` bumped in `Chart.yaml` (unchanged versions are skipped by `make build`)
+- [ ] `values.yaml` is minimal, documented, and global values are commented out, not set (see Values files below)
+- [ ] `values.example.yaml` present with realistic, non-secret values
+- [ ] `values.lint.yaml` present if `helm lint` needs cluster/environment globals not in `values.yaml`
+- [ ] `values.schema.json` present and validates `values.example.yaml`
+- [ ] `tests/snapshot_test.yaml` present and covers meaningful edge cases, not just the default snapshot
+- [ ] `namespace: {{ .Release.Namespace }}` set on every resource
+- [ ] No hardcoded cluster/environment values — `apc-global-overrides` helpers used throughout
+- [ ] `make lint CHARTFOLDER=<chart>` and `make unittest CHARTFOLDER=<chart>` both pass
+- [ ] PR opened (not merged, not published) with the Jira ticket ID in the branch/PR name
 
-When editing existing code:
-- Don't "improve" adjacent code, comments, or formatting.
-- Don't refactor things that aren't broken.
-- Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
-
-When your changes create orphans:
-- Remove imports/variables/functions that YOUR changes made unused.
-- Don't remove pre-existing dead code unless asked.
-
-The test: Every changed line should trace directly to the user's request.
-
-### Goal-Driven Execution
-
-**Define success criteria. Loop until verified.**
-
-Transform tasks into verifiable goals:
-- "Add validation" → "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" → "Write a test that reproduces it, then make it pass"
-- "Refactor X" → "Ensure tests pass before and after"
-
-For multi-step tasks, state a brief plan:
-```
-1. [Step] → verify: [check]
-2. [Step] → verify: [check]
-3. [Step] → verify: [check]
-```
-
-Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
-
-## Guidance for reviews
-
-- Prefer concise bullet points; include code snippets when helpful.
-- When you flag an issue, always include: (a) the rationale, (b) a suggested change, and (c) a quick check to verify the fix.
-- If multiple valid approaches exist, list the recommended one first and briefly note trade‑offs.
-
-### Tone & format
-
-- Be direct, specific, and constructive.
-- Use headings, checklists, and short code blocks for readability.
-- Avoid vague feedback; instead, provide clear, actionable guidance.
-
-### Security & reliability (applies to all code)
-
-- Default to secure, least‑privilege configurations.
-- Call out deprecated APIs, unstable flags, or risky defaults and propose supported alternatives.
+If you're unsure whether something is genuinely required or just convenient, default to leaving it out — see values.yaml Conventions.
 
 ## Directory Layout
 
 ```
 charts-openshift/
-├── charts/                  # All Helm charts (77+ charts)
+├── charts/                  # All Helm charts (80+ charts)
 ├── library-charts-unittests/ # Unit tests for library charts such as apc-global-overrides
 ├── packaged_charts/         # Pre-built .tgz packages (do not edit by hand)
 ├── index.yaml               # Helm repo index (generated by `make build`)
@@ -152,8 +115,28 @@ tests:
 ```
 
 - All charts include a snapshot test usually consuming the `values.example.yaml` file.
-- Charts should include proper unittests, covering all edge cases
+- Charts should include proper unittests, covering all edge cases.
 - Run all tests: `make unittest` (runs `helm unittest --strict <folder>` for every chart with a `tests/` dir).
+
+## Templates & naming conventions
+
+- Always set `namespace: {{ .Release.Namespace }}` in every manifest (rendered manifest pattern requirement).
+- Prefer flat over nested values, e.g. `clusterName` over `cluster.name`.
+- Each resource definition should be in its own template file.
+- Prefer indented YAML sequences:
+
+  ```yaml
+  sequence:
+    - one
+    - two
+  ```
+
+- Component naming — simple names, no prefix, suffix only when necessary:
+  - `<component>` — single resource, e.g. `remove-kubeadmin`
+  - `<component>-operator` / `<component>-helm` — operator/chart installation only; no followup configuration
+  - `<component>-config` / `<component>-instance` / `<component>-policies` — configuration using CRs created during installation
+- Operator installation — use an ACM `operatorpolicy` to install operators, and approve only allowed versions.
+- Follow <https://learnk8s.io/production-best-practices> and the [Helm chart best practices](https://helm.sh/docs/chart_best_practices/).
 
 ## PrometheusRule Conventions
 
@@ -172,43 +155,7 @@ spec:
             team: platform
 ```
 
-## Conventions
-
-- Follow <https://learnk8s.io/production-best-practices> for k8s manifests
-
-### Helm best practices
-
-- Follow helm best practices - <https://helm.sh/docs/chart_best_practices/>, e.g.
-
-### YAML formatting
-
-Prefer indented sequences:
-
-```yaml
-sequence:
-  - one
-  - two
-```
-
-### Component naming
-
-Use simple component names with no prefix. Suffix when necessary:
-
-- `<component>` — single resource, e.g. `remove-kubeadmin`
-- `<component>-operator` / `<component>-helm` — operator/chart installation only; no followup configuration
-- `<component>-config` / `<component>-instance` / `<component>-policies` — configuration using CRs created during installation
-
-### Templates
-
-- Always set `namespace: {{ .Release.Namespace }}` in every manifest (rendered manifest pattern requirement).
-- Prefer flat over nested values, e.g. `clusterName` over `cluster.name`.
-- Each resource definition should be in its own template file.
-
-### Operator installation
-
-- ACM operatorpolicy should be used to install operators, and approve only allowed versions
-
-### Things to avoid
+## Things to avoid
 
 - **Extra objects / extraManifests** — do not implement for APC charts; keep complexity in the chart, not in the config repo.
 - **Helm lookup** — makes deployment non-deterministic; incompatible with rendered-manifest GitOps. Use Kyverno or Crossplane instead.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,8 @@ Charts are consumed from a separate per-customer **conf repo** via `helmfile` an
 ## Repository & agent boundaries
 
 - This repo only produces charts (`charts/`, `packaged_charts/`, `index.yaml`). It has no knowledge of a specific customer or cluster — that lives entirely in the conf repo.
-- The conf repo is a **separate git repository**, typically checked out as a sibling directory. It holds two things relevant to chart work:
+- There is no single "the conf repo" — every customer has their own (`conf-<customer>`, e.g. `conf-socpoist`), each typically checked out as a sibling directory. Which one is relevant to a given task is never inferrable from charts-openshift alone: resolve it from what's already granted in the local session (e.g. `.claude/settings.local.json`) or from context already stated in the task; if it's still not clear — especially if more than one `conf-*` sibling exists — ask rather than picking one.
+- Once you know which conf repo applies, it holds two things relevant to chart work:
   - `gitops/components/<component>/values.<common|dev01|test01|prod01>.yaml.gotmpl` — the helmfile values fed into charts already under GitOps.
   - `ocp-<environment>/<component>/*.yaml` — static manifests for objects deployed **before** GitOps existed, not yet backed by a chart. These are the source material when migrating a component to a chart.
 - Read the conf repo for context (existing values, static manifests to migrate) but never edit, commit, or push there — changes to the conf repo happen in that repo's own session, with its own review.
@@ -41,6 +42,23 @@ A chart change is not finished until:
 - [ ] PR opened (not merged, not published) with the Jira ticket ID in the branch/PR name
 
 If you're unsure whether something is genuinely required or just convenient, default to leaving it out — see values.yaml Conventions.
+
+## Guidance for reviews
+
+- Prefer concise bullet points; include code snippets when helpful.
+- When you flag an issue, always include: (a) the rationale, (b) a suggested change, and (c) a quick check to verify the fix.
+- If multiple valid approaches exist, list the recommended one first and briefly note trade‑offs.
+
+### Tone & format
+
+- Be direct, specific, and constructive.
+- Use headings, checklists, and short code blocks for readability.
+- Avoid vague feedback; instead, provide clear, actionable guidance.
+
+### Security & reliability (applies to all code)
+
+- Default to secure, least‑privilege configurations.
+- Call out deprecated APIs, unstable flags, or risky defaults and propose supported alternatives.
 
 ## Directory Layout
 


### PR DESCRIPTION
- defining boundaries for agents
- creating skills for new chart and for migration chart, once all the static manifests are migrated the migration skill can be removed
- copilot-instructions.md refactore, still linked to CLAUDE.md and AGENTS.md